### PR TITLE
release/v0.2.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,12 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Compute Engine Instances
     - Cloud Storage Buckets
 
+### Changed
+- CICD pipeline migrated from CircleCI to Github Actions
+
 ## [0.2.0] - 09-09-2023
 ### Added
 - Changelog for release announcements.
 - MissionKey CRD for storing cloud provider credentials
 - Issue templates for testing and documentation.
-- CICD pipeline migrated from CircleCI to Github Actions
 
 ### Changed
 - Fixed CICD linting and added artifacts for outputs.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.1] - 09-23-2023
 ### Added
 - Enabled multi-group settings and changed structure as specified by kubebuilder.
 - Unit tests for common utility functions and mission related methods


### PR DESCRIPTION
## Release Notes

# Changed
CICD pipeline migrated from CircleCI to Github Actions 6581481
Documentation changes d2c8cfa
Fixed CICD pipeline failing after kubebuilder v4 layout change. 09ab432

# Added
Mission related methods in utility folder df0677a
Storage Buckets CRD for GCP 010b16b
Created hackfolders d9de5c3
VirutalMachine CRD and compatability with GCP's compute engine instances. Only simple parameters are supported so far. f427e73
Unit tests for utility functions. 859d945
Enabled multi-group settings and changed structure as specified by kubebuilder. c227def